### PR TITLE
Install provisioning profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.0
+
+- Support for installing a provisioning profile
+
 ## 1.2.0
 
-- Support for Xcode 8 provisioning
+- Support for Xcode 8 provisioning profile specifier

--- a/Fastfile
+++ b/Fastfile
@@ -2,6 +2,9 @@ fastlane_version "1.55.0"
 
 default_platform :ios
 
+  before_all do
+  end
+
   lane :test do
     setup()
     scan
@@ -27,7 +30,7 @@ default_platform :ios
   end
 
   def build_with_gym()
-    install_provisioning_profile()
+    install_provisioning_profile
     provisioning_profile_name = ENV['TAB_PROVISIONING_PROFILE']
     if provisioning_profile_name != nil
       xcconfig_filename = Dir.pwd + "/TAB.release.xcconfig"
@@ -35,15 +38,6 @@ default_platform :ios
       gym(use_legacy_build_api: true, xcconfig: xcconfig_filename)
     else
       gym(use_legacy_build_api: true)
-    end
-  end
-
-  def install_provisioning_profile()
-    if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
-      provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
-      provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
-      provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
-      `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
     end
   end
 

--- a/Fastfile
+++ b/Fastfile
@@ -4,9 +4,18 @@ default_platform :ios
 
   before_all do
     if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
+      puts "TAB_PROVISIONING_PROFILE_PATH added"
+      current_dir = `pwd`
+      puts current_dir
       path = ENV['TAB_PROVISIONING_PROFILE_PATH']
+      puts path
+      path = path.gsub("fastlane/", "")
+      puts path
+
       uuid = `grep UUID -A1 -a #{path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
+      puts uuid
       destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{uuid.strip}.mobileprovision"
+      puts destination
       `cp #{path} #{destination}`
     end
   end

--- a/Fastfile
+++ b/Fastfile
@@ -3,6 +3,12 @@ fastlane_version "1.55.0"
 default_platform :ios
 
   before_all do
+    if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
+      path = ENV['TAB_PROVISIONING_PROFILE_PATH']
+      uuid = `grep UUID -A1 -a #{path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
+      destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{uuid.strip}.mobileprovision"
+      `cp #{path} #{destination}`
+    end
   end
 
   lane :test do

--- a/Fastfile
+++ b/Fastfile
@@ -9,7 +9,7 @@ default_platform :ios
       puts current_dir
       path = ENV['TAB_PROVISIONING_PROFILE_PATH']
       puts path
-      path = path.gsub("fastlane/", "")
+      path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
       puts path
 
       uuid = `grep UUID -A1 -a #{path} | grep -io \"[-A-Z0-9]\\{36\\}\"`

--- a/Fastfile
+++ b/Fastfile
@@ -2,15 +2,6 @@ fastlane_version "1.55.0"
 
 default_platform :ios
 
-  before_all do
-    if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
-      provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
-      provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
-      provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
-      `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
-    end
-  end
-
   lane :test do
     setup()
     scan
@@ -36,6 +27,7 @@ default_platform :ios
   end
 
   def build_with_gym()
+    install_provisioning_profile()
     provisioning_profile_name = ENV['TAB_PROVISIONING_PROFILE']
     if provisioning_profile_name != nil
       xcconfig_filename = Dir.pwd + "/TAB.release.xcconfig"
@@ -43,6 +35,15 @@ default_platform :ios
       gym(use_legacy_build_api: true, xcconfig: xcconfig_filename)
     else
       gym(use_legacy_build_api: true)
+    end
+  end
+
+  def install_provisioning_profile()
+    if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
+      provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
+      provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
+      provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
+      `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
     end
   end
 

--- a/Fastfile
+++ b/Fastfile
@@ -4,19 +4,10 @@ default_platform :ios
 
   before_all do
     if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
-      puts "TAB_PROVISIONING_PROFILE_PATH added"
-      current_dir = `pwd`
-      puts current_dir
-      path = ENV['TAB_PROVISIONING_PROFILE_PATH']
-      puts path
-      path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
-      puts path
-
-      uuid = `grep UUID -A1 -a #{path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
-      puts uuid
-      destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{uuid.strip}.mobileprovision"
-      puts destination
-      `cp #{path} #{destination}`
+      provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
+      provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
+      provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
+      `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
     end
   end
 

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -24,39 +24,18 @@ module Fastlane
         "Installs a provisioning profile from a path"
       end
 
-      def self.details
-        # Optional:
-        # this is your chance to provide a more detailed description of this action
-        # "You can use this action to do cool things..."
-      end
-
       def self.available_options
-        # Define all options your action supports. 
-        
-        # Below a few examples
         [
           FastlaneCore::ConfigItem.new(key: :development,
                                        env_name: "TAB_PROVISIONING_PROFILE_PATH",
                                        description: "The path of the provisioning profile to install",
+                                       is_optional: false,
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false) # the default value if the user didn't provide one
         ]
       end
 
-      def self.output
-        # Define the shared values you are going to provide
-        # Example
-        # [
-        #   ['INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE', 'A description of what this value contains']
-        # ]
-      end
-
-      def self.return_value
-        # If you method provides a return value, you can describe here what it does
-      end
-
       def self.authors
-        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
         ["Luciano Marisi @lucianomarisi"]
       end
 

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -6,20 +6,14 @@ module Fastlane
 
     class InstallProvisioningProfileAction < Action
       def self.run(params)
-        # fastlane will take care of reading in the parameter and fetching the environment variable:
-        # I.message "Parameter API Token: #{params[:api_token]}
         if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
-          variable = `pwd`
-          puts `pwd`
-          puts variable
           provisioning_profile_path=ENV['TAB_PROVISIONING_PROFILE_PATH']
           provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
           provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
           `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
           UI.success("Installed profile at path #{params[:provisioning_profile_path]} succesfully")
         else 
-          UI.error("TAB_PROVISIONING_PROFILE_PATH not provided")
-          UI.user_error! "Provide TAB_PROVISIONING_PROFILE_PATH"
+          UI.user_error! "TAB_PROVISIONING_PROFILE_PATH not defined"
         end
       end
 

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -12,7 +12,7 @@ module Fastlane
           variable = `pwd`
           puts `pwd`
           puts variable
-          provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
+          provisioning_profile_path=ENV['TAB_PROVISIONING_PROFILE_PATH']
           provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
           provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
           `cp #{provisioning_profile_path} #{provisioning_profile_destination}`

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -13,7 +13,7 @@ module Fastlane
           `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
           UI.success("Installed profile at path #{params[:provisioning_profile_path]} succesfully")
         else 
-          UI.user_error! "TAB_PROVISIONING_PROFILE_PATH not defined"
+          UI.message("Skipping installing provisioning profile since TAB_PROVISIONING_PROFILE_PATH is not defined")
         end
       end
 

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -7,12 +7,15 @@ module Fastlane
     class InstallProvisioningProfileAction < Action
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
-        # UI.message "Parameter API Token: #{params[:api_token]}"
+        # I.message "Parameter API Token: #{params[:api_token]}
         if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
           provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
           provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
           provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
           `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
+          UI.message("Install profile succesfully")
+        else 
+          UI.message "Parameter API Token: #{params[:provisioning_profile_path]}"
         end
       end
 
@@ -26,7 +29,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :development,
+          FastlaneCore::ConfigItem.new(key: :provisioning_profile_path,
                                        env_name: "TAB_PROVISIONING_PROFILE_PATH",
                                        description: "The path of the provisioning profile to install",
                                        is_string: false, # true: verifies the input is a string, false: every kind of value

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -1,0 +1,68 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE = :INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE
+    end
+
+    class InstallProvisioningProfileAction < Action
+      def self.run(params)
+        # fastlane will take care of reading in the parameter and fetching the environment variable:
+        UI.message "Parameter API Token: #{params[:api_token]}"
+        if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
+          provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
+          provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
+          provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
+          `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Installs a provisioning profile from a path"
+      end
+
+      def self.details
+        # Optional:
+        # this is your chance to provide a more detailed description of this action
+        # "You can use this action to do cool things..."
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :development,
+                                       env_name: "TAB_PROVISIONING_PROFILE_PATH",
+                                       description: "The path of the provisioning profile to install",
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        # Define the shared values you are going to provide
+        # Example
+        # [
+        #   ['INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE', 'A description of what this value contains']
+        # ]
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["Luciano Marisi @lucianomarisi"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -7,7 +7,7 @@ module Fastlane
     class InstallProvisioningProfileAction < Action
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
-        UI.message "Parameter API Token: #{params[:api_token]}"
+        # UI.message "Parameter API Token: #{params[:api_token]}"
         if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
           provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
           provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
@@ -29,7 +29,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :development,
                                        env_name: "TAB_PROVISIONING_PROFILE_PATH",
                                        description: "The path of the provisioning profile to install",
-                                       is_optional: false,
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false) # the default value if the user didn't provide one
         ]

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -18,7 +18,8 @@ module Fastlane
           `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
           UI.success("Installed profile at path #{params[:provisioning_profile_path]} succesfully")
         else 
-          UI.error("Could not find provisioning path at path #{params[:provisioning_profile_path]}")
+          UI.error("TAB_PROVISIONING_PROFILE_PATH not provided")
+          UI.user_error! "Provide TAB_PROVISIONING_PROFILE_PATH"
         end
       end
 

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -9,7 +9,9 @@ module Fastlane
         # fastlane will take care of reading in the parameter and fetching the environment variable:
         # I.message "Parameter API Token: #{params[:api_token]}
         if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
-          `pwd`
+          variable = `pwd`
+          puts `pwd`
+          puts variable
           provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
           provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
           provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -18,7 +18,7 @@ module Fastlane
           `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
           UI.success("Installed profile at path #{params[:provisioning_profile_path]} succesfully")
         else 
-          UI.message "Parameter API Token: #{params[:provisioning_profile_path]}"
+          UI.error("Could not find provisioning path at path #{params[:provisioning_profile_path]}")
         end
       end
 

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -9,11 +9,12 @@ module Fastlane
         # fastlane will take care of reading in the parameter and fetching the environment variable:
         # I.message "Parameter API Token: #{params[:api_token]}
         if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
+          `pwd`
           provisioning_profile_path="../#{ENV['TAB_PROVISIONING_PROFILE_PATH']}" # needed because fastlane runs in the fastlane directory
           provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
           provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
           `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
-          UI.message("Install profile succesfully")
+          UI.success("Installed profile at path #{params[:provisioning_profile_path]} succesfully")
         else 
           UI.message "Parameter API Token: #{params[:provisioning_profile_path]}"
         end


### PR DESCRIPTION
Added new configuration to install a provisioning profile to work with Xcode 8.

`TAB_PROVISIONING_PROFILE_PATH` is now used to specify the path of the  provisioning profile to install

This may be better as a fastlane action, so if anybody with decent ruby skills could help that would be much appreciated

fixes #3 