### PR TITLE
Feature/remove provfile

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -123,15 +123,8 @@ def _build_with_gym()
   provisioning_profile_name = ENV['TAB_PROVISIONING_PROFILE']
   export_method = _get_export_method()
   xcconfig_filename = Dir.pwd + "/TAB.release.xcconfig"
-  if File.file?("Provfile")
-    _create_xcconfig()
-    gym(export_method: export_method, xcconfig: xcconfig_filename)
-  elsif provisioning_profile_name != nil
-    File.write(xcconfig_filename, "PROVISIONING_PROFILE_SPECIFIER = #{provisioning_profile_name}\n")
-    gym(export_method: export_method, xcconfig: xcconfig_filename)
-  else
-    gym(export_method: export_method)
-  end
+  _create_xcconfig()
+  gym(export_method: export_method, xcconfig: xcconfig_filename)
 end
 
 def _get_export_method()
@@ -168,7 +161,7 @@ def _create_xcconfig()
   # TODO: Ignore test targets
   # TODO: Replace spaces with underscores
   # TODO: Environment variable for project
-  project = Xcodeproj::Project.open(ENV['FL_PROJECT_SIGNING_PROJECT_PATH'])
+  project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
   project.targets.each do |target|
     profile = _get_profile_for_target(target)
     sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> TAB.release.xcconfig"

--- a/Fastfile
+++ b/Fastfile
@@ -167,7 +167,7 @@ def _create_xcconfig(filename)
       sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> #{filename}"
     end
   end
-  sh "echo \"PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}\""
+  sh "echo \"PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)\" >> #{filename}"
 end
 
 def _get_profile_for_target(target)

--- a/Fastfile
+++ b/Fastfile
@@ -164,7 +164,9 @@ def _create_xcconfig()
   project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
   project.targets.each do |target|
     profile = _get_profile_for_target(target)
-    sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> TAB.release.xcconfig"
+    if profile.nil?
+      sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> TAB.release.xcconfig"
+    end
   end
   sh 'echo \'PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROVISIONING_PROFILE)\' >> TAB.release.xcconfig'
 end

--- a/Fastfile
+++ b/Fastfile
@@ -161,13 +161,15 @@ def _create_xcconfig(filename)
   # TODO: Replace spaces with underscores?
   # TODO: Try not to need `TAB_PROJECT_PATH`
   project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
+  lines = []
   project.targets.each do |target|
     profile = _get_profile_for_target(target)
     if !profile.nil?
-      sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> #{filename}"
+      lines.push("#{target.name}_PROFILE_SPECIFIER=#{profile}")
     end
   end
-  sh "echo 'PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)' >> #{filename}"
+  lines.push("PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)")
+  File.write(filename, lines.join("\n"))
 end
 
 def _get_profile_for_target(target)

--- a/Fastfile
+++ b/Fastfile
@@ -167,7 +167,7 @@ def _create_xcconfig(filename)
       sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> #{filename}"
     end
   end
-  sh "echo PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}"
+  sh "echo `PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}`"
 end
 
 def _get_profile_for_target(target)

--- a/Fastfile
+++ b/Fastfile
@@ -118,9 +118,9 @@ def _build_ipa()
 end
 
 def _build_with_gym()
+  # TODO: `install_provisioning_profile` only installs the provisioning profile for the main target
   install_provisioning_profile
   _update_team_id_if_necessary
-  provisioning_profile_name = ENV['TAB_PROVISIONING_PROFILE']
   export_method = _get_export_method()
   xcconfig_filename = Dir.pwd + "/TAB.release.xcconfig"
   _create_xcconfig()
@@ -158,9 +158,8 @@ def _get_team_id()
 end
 
 def _create_xcconfig()
-  # TODO: Ignore test targets
-  # TODO: Replace spaces with underscores
-  # TODO: Environment variable for project
+  # TODO: Replace spaces with underscores?
+  # TODO: Try not to need `TAB_PROJECT_PATH`
   project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
   project.targets.each do |target|
     profile = _get_profile_for_target(target)
@@ -172,7 +171,6 @@ def _create_xcconfig()
 end
 
 def _get_profile_for_target(target)
-  # TODO: Environment variable for plist
   config = target.build_configurations.first
   bundleID = config.build_settings['PRODUCT_BUNDLE_IDENTIFIER']
   profilesHash = get_info_plist_value(path: ENV['GYM_EXPORT_OPTIONS'], key: "provisioningProfiles")

--- a/Fastfile
+++ b/Fastfile
@@ -167,7 +167,7 @@ def _create_xcconfig(filename)
       sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> #{filename}"
     end
   end
-  sh "echo `PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}`"
+  sh "echo \"PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}\"""
 end
 
 def _get_profile_for_target(target)

--- a/Fastfile
+++ b/Fastfile
@@ -167,7 +167,7 @@ def _create_xcconfig(filename)
       sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> #{filename}"
     end
   end
-  sh "echo \"PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)\" >> #{filename}"
+  sh "echo 'PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)' >> #{filename}"
 end
 
 def _get_profile_for_target(target)

--- a/Fastfile
+++ b/Fastfile
@@ -167,7 +167,7 @@ def _create_xcconfig(filename)
       sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> #{filename}"
     end
   end
-  sh "echo \"PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}\"""
+  sh "echo \"PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}\""
 end
 
 def _get_profile_for_target(target)

--- a/Fastfile
+++ b/Fastfile
@@ -164,7 +164,7 @@ def _create_xcconfig()
   project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
   project.targets.each do |target|
     profile = _get_profile_for_target(target)
-    if profile.nil?
+    if !profile.nil?
       sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> TAB.release.xcconfig"
     end
   end

--- a/Fastfile
+++ b/Fastfile
@@ -168,7 +168,7 @@ def _create_xcconfig()
       sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> TAB.release.xcconfig"
     end
   end
-  sh 'echo \'PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROVISIONING_PROFILE)\' >> TAB.release.xcconfig'
+  sh 'echo \'PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)\' >> TAB.release.xcconfig'
 end
 
 def _get_profile_for_target(target)

--- a/Fastfile
+++ b/Fastfile
@@ -118,12 +118,11 @@ def _build_ipa()
 end
 
 def _build_with_gym()
-  # TODO: `install_provisioning_profile` only installs the provisioning profile for the main target
   install_provisioning_profile
   _update_team_id_if_necessary
   export_method = _get_export_method()
   xcconfig_filename = Dir.pwd + "/TAB.release.xcconfig"
-  _create_xcconfig(xcconfig_filename)
+  create_xcconfig(filename: xcconfig_filename)
   gym(export_method: export_method, xcconfig: xcconfig_filename)
 end
 
@@ -155,27 +154,6 @@ def _get_team_id()
     team_id = get_info_plist_value(path: ENV['GYM_EXPORT_OPTIONS'], key: "teamID")
   end
   team_id
-end
-
-def _create_xcconfig(filename)
-  # TODO: Try not to need `TAB_PROJECT_PATH`
-  project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
-  lines = []
-  project.targets.each do |target|
-    profile = _get_profile_for_target(target)
-    if !profile.nil?
-      lines.push("#{target.name}_PROFILE_SPECIFIER=#{profile}")
-    end
-  end
-  lines.push("PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)")
-  File.write(filename, lines.join("\n"))
-end
-
-def _get_profile_for_target(target)
-  config = target.build_configurations.first
-  bundleID = config.build_settings['PRODUCT_BUNDLE_IDENTIFIER']
-  profilesHash = get_info_plist_value(path: ENV['GYM_EXPORT_OPTIONS'], key: "provisioningProfiles")
-  profilesHash[bundleID]
 end
 
 def _upload_to_hockey()

--- a/Fastfile
+++ b/Fastfile
@@ -158,7 +158,6 @@ def _get_team_id()
 end
 
 def _create_xcconfig(filename)
-  # TODO: Replace spaces with underscores?
   # TODO: Try not to need `TAB_PROJECT_PATH`
   project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
   lines = []

--- a/Fastfile
+++ b/Fastfile
@@ -123,7 +123,7 @@ def _build_with_gym()
   _update_team_id_if_necessary
   export_method = _get_export_method()
   xcconfig_filename = Dir.pwd + "/TAB.release.xcconfig"
-  _create_xcconfig()
+  _create_xcconfig(xcconfig_filename)
   gym(export_method: export_method, xcconfig: xcconfig_filename)
 end
 
@@ -157,17 +157,17 @@ def _get_team_id()
   team_id
 end
 
-def _create_xcconfig()
+def _create_xcconfig(filename)
   # TODO: Replace spaces with underscores?
   # TODO: Try not to need `TAB_PROJECT_PATH`
   project = Xcodeproj::Project.open(ENV['TAB_PROJECT_PATH'])
   project.targets.each do |target|
     profile = _get_profile_for_target(target)
     if !profile.nil?
-      sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> TAB.release.xcconfig"
+      sh "echo \"#{target.name}_PROFILE_SPECIFIER=#{profile}\" >> #{filename}"
     end
   end
-  sh 'echo \'PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)\' >> TAB.release.xcconfig'
+  sh "echo PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER) >> #{filename}"
 end
 
 def _get_profile_for_target(target)

--- a/README.md
+++ b/README.md
@@ -56,25 +56,6 @@ For more detailed instructions [see our wiki](https://github.com/theappbusiness/
 
 For more detailed information on how to setup your project and environment please see our [wiki](https://github.com/theappbusiness/MasterFastfile/wiki)
 
-## Provfiles
-
-If you wish to support multiple extensions in your application using different provisioning profiles you will need to define a Provfile. In your Provfile you define your separate target names (aka MyApp, MyWatchExtension) and the provisioning profile name to be used with them e.g.
-
-```
-target 'MyApp' do
-  "MyAppProvisioningProfileName"
-end
-
-target 'MyWatchExtension' do
-  "MyWatchExtensionProvisioningProfileName"
-end
-
-target 'MyOtherExtension' do
-  # MY_OTHER_EXTENSION_PROFILE_NAME could be defined in a .env file allowing support for multiple environments.
-  ENV['MY_OTHER_EXTENSION_PROFILE_NAME']
-end
-```
-
 ## Dependencies
 
 ### Imagemagick

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ For more detailed instructions [see our wiki](https://github.com/theappbusiness/
 
 For more detailed information on how to setup your project and environment please see our [wiki](https://github.com/theappbusiness/MasterFastfile/wiki)
 
+## Code signing
+
+From Xcode 9 and onwards you are required to provide an export options plist. The MasterFastfile uses this to its advantage to handle as much code signing stuff as it can on your behalf.
+
+For the MasterFastfile to fully take advantage of your export options ensure that you have defined the following environment variables:
+
+- `GYM_EXPORT_OPTIONS`: The path to your export options, see below for how to generate these (you can choose different export options for different environments this way).
+- `FL_PROJECT_SIGNING_PROJECT_PATH`: The path to your main Xcode project (not your workspace).
+- `FL_UPDATE_PLIST_APP_IDENTIFIER`: The bundle identifier you want your main app target to have (you can choose a different identifier for different environments).
+
+Export options define which provisioning profiles to use for which targets, as well as stuff like the team and export type.
+The easiest way to figure out what your export options plist should contain is to manually set up code signing in Xcode\*, archive your app and then click "export...". Once exported, in the directory Xcode creates you'll be able to find an `ExportOptions.plist` file.
+
+The MasterFastfile uses whichever export options you have set for the `GYM_EXPORT_OPTIONS` environment variable to determine which provisioning profiles to use, as well as automatically detect which team should be used to code sign the app, and which export option to use.
+
+\*It's recommended to do this at least once anyway. You'll know for sure whether you have your code signing set up correctly, which will help debug issues you might encounter while using Fastlane.
+
 ## Dependencies
 
 ### Imagemagick

--- a/actions/create_xcconfig.rb
+++ b/actions/create_xcconfig.rb
@@ -1,8 +1,5 @@
 module Fastlane
   module Actions
-    module SharedValues
-    end
-
     class CreateXcconfigAction < Action
       def self.run(params)
         filename = params[:filename]

--- a/actions/create_xcconfig.rb
+++ b/actions/create_xcconfig.rb
@@ -22,7 +22,6 @@ module Fastlane
         else
           UI.success("Successfully created #{filename}")
         end
-
       end
 
       def self.get_profile_for_target(target)

--- a/actions/create_xcconfig.rb
+++ b/actions/create_xcconfig.rb
@@ -1,7 +1,6 @@
 module Fastlane
   module Actions
     module SharedValues
-      INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE = :INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE
     end
 
     class CreateXcconfigAction < Action

--- a/actions/create_xcconfig.rb
+++ b/actions/create_xcconfig.rb
@@ -1,0 +1,66 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE = :INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE
+    end
+
+    class CreateXcconfigAction < Action
+      def self.run(params)
+        filename = params[:filename]
+        project = Xcodeproj::Project.open(ENV['FL_PROJECT_SIGNING_PROJECT_PATH'])
+        lines = []
+        project.targets.each do |target|
+          profile = self.get_profile_for_target(target)
+          if !profile.nil?
+            lines.push("#{target.name}_PROFILE_SPECIFIER=#{profile}")
+          end
+        end
+        lines.push("PROVISIONING_PROFILE_SPECIFIER=$($(TARGET_NAME)_PROFILE_SPECIFIER)")
+        begin
+          File.write(filename, lines.join("\n"))
+        rescue => exception
+          UI.error(exception)
+        else
+          UI.success("Successfully created #{filename}")
+        end
+
+      end
+
+      def self.get_profile_for_target(target)
+        config = target.build_configurations.first
+        bundleID = config.build_settings['PRODUCT_BUNDLE_IDENTIFIER']
+        action = Fastlane::Actions::GetInfoPlistValueAction
+        profilesHash = action.run(path: ENV['GYM_EXPORT_OPTIONS'], key: "provisioningProfiles")
+        profilesHash[bundleID]
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Creates an xcconfig file for provisioning"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :filename,
+                                       env_name: "TAB_XCCONFIG_FILENAME",
+                                       description: "The name of the xcconfig to create",
+                                       is_string: true,
+                                       default_value: "TAB.release.xcconfig")
+        ]
+      end
+
+      def self.authors
+        [
+          "Kane Cheshire ✨ @KaneCheshire"
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/actions/create_xcconfig.rb
+++ b/actions/create_xcconfig.rb
@@ -29,8 +29,7 @@ module Fastlane
       def self.get_profile_for_target(target)
         config = target.build_configurations.first
         bundleID = config.build_settings['PRODUCT_BUNDLE_IDENTIFIER']
-        action = Fastlane::Actions::GetInfoPlistValueAction
-        profilesHash = action.run(path: ENV['GYM_EXPORT_OPTIONS'], key: "provisioningProfiles")
+        profilesHash = GetInfoPlistValueAction.run(path: ENV['GYM_EXPORT_OPTIONS'], key: "provisioningProfiles")
         profilesHash[bundleID]
       end
 

--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,8 @@ function make_default_env_file {
 #This is your default environment file
 #Set environment variables used in all builds here
 #More information on available environment variables can be found here https://github.com/theappbusiness/MasterFastfile/wiki/Quick-simple-setup-using-TAB-defaults
+
+FL_PROJECT_SIGNING_PROJECT_PATH="./yourproject.xcodeproj" # Path to your project (not workspace)
 FL_HOCKEY_API_TOKEN="" #Hocky API Token
 FL_HOCKEY_OWNER_ID="" #Hockey Organisation ID (number not name)
 FL_UPDATE_PLIST_PATH="" #Path to Info.plist


### PR DESCRIPTION
- This PR removes the need to include a Provfile, instead opting to take advantage of the fact all projects now require an export options plist.
- Previously, the xcconfig file was created by parsing the Provfile, essentially the same thing is happening except now it maps bundle IDs from the export options to targets in the Xcode project.
- Additionally, `TAB_PROVISIONING_PROFILE` can technically be removed now I think, but leaving it in for the time being as it's not really related to this PR. `TAB_PROVISIONING_PROFILE` is still used in the `install_provisioning_profile` action, however I think this needs to be revisited because it only installs one profile for the main target (or whatever you have `TAB_PROVISIONING_PROFILE` set to). So my understanding is the MasterFastfile wouldn't work with multiple targets if you don't install the profiles manually.