### PR TITLE
Automatically installs any profiles that are included in the Fastlane setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # MasterFastfile
 
-[![Release](https://img.shields.io/badge/release-2.3.0-green.svg)](https://github.com/theappbusiness/MasterFastfile/releases/tag/2.3.0)
+[![Release](https://img.shields.io/badge/release-3.0.0-green.svg)](https://github.com/theappbusiness/MasterFastfile/releases/tag/3.0.0)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/theappbusiness/MasterFastfile/blob/master/LICENSE)
 
 To setup your project to use the TAB MasterFastfile, navigate to your project root and run the following command:
@@ -29,6 +29,7 @@ For more detailed instructions [see our wiki](https://github.com/theappbusiness/
 * `deploy_to_hockey`
   * runs tests
   * sets build number
+  * installs provisioning profiles (if any are included in your Fastlane directory)
   * adds build info to app icon
   * builds and archives project
   * generates changelog from git commits
@@ -36,20 +37,26 @@ For more detailed instructions [see our wiki](https://github.com/theappbusiness/
 * `deploy_to_hockey_no_test`
   * sets build number
   * adds build info to app icon
+  * installs provisioning profiles
   * builds and archives project
   * generates changelog from git commits
   * uploads app to hockey
 * `deploy_to_test_flight` (How do I find my iTunes Connect team ID? [link](https://github.com/fastlane/fastlane/issues/4301#issuecomment-253461017))
   * runs tests
   * sets build number
+  * installs provisioning profiles
   * adds build info to app icon
   * builds and archives project
   * uploads app to test flight
 * `local_build`
   * optionally adds icon overlay: e.g. `fastlane local_build icon_overlay:true`
+  * installs provisioning profiles
   * builds an ipa
 
 ## Custom Actions
+
+* `install_provisioning_profile`
+  * Automatically installs any provisioning profiles included in your Fastlane directory
 
 * `icon_overlay`
   * Adds overlay to app icon containing build information

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For more detailed instructions [see our wiki](https://github.com/theappbusiness/
 
 ## Custom Actions
 
-* `install_provisioning_profile`
+* `install_provisioning_profiles`
   * Automatically installs any provisioning profiles included in your Fastlane directory
 
 * `icon_overlay`

--- a/actions/install_provisioning_profile.rb
+++ b/actions/install_provisioning_profile.rb
@@ -1,19 +1,20 @@
 module Fastlane
   module Actions
     module SharedValues
-      INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE = :INSTALL_PROVISIONING_PROFILE_CUSTOM_VALUE
     end
 
     class InstallProvisioningProfileAction < Action
       def self.run(params)
-        if ENV['TAB_PROVISIONING_PROFILE_PATH'] != nil
-          provisioning_profile_path=ENV['TAB_PROVISIONING_PROFILE_PATH']
-          provisioning_profile_uuid = `grep UUID -A1 -a #{provisioning_profile_path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
-          provisioning_profile_destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{provisioning_profile_uuid.strip}.mobileprovision"
-          `cp #{provisioning_profile_path} #{provisioning_profile_destination}`
-          UI.success("Installed profile at path #{params[:provisioning_profile_path]} succesfully")
-        else 
-          UI.message("Skipping installing provisioning profile since TAB_PROVISIONING_PROFILE_PATH is not defined")
+        profile_paths = Dir.glob("./**/*.mobileprovision")
+        if profile_paths.empty?
+          UI.message("Skipping installing provisioning profiles since no profiles were found.")
+        else
+          profile_paths.each do |path|
+            uuid = `grep UUID -A1 -a #{path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
+            destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{uuid.strip}.mobileprovision"
+            `cp #{path} #{destination}`
+            UI.success("Installed profile at path #{path} succesfully")
+          end
         end
       end
 
@@ -22,21 +23,18 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Installs a provisioning profile from a path"
+        "Installs all local provisioning profiles contained within the directory this action is run in."
       end
 
       def self.available_options
-        [
-          FastlaneCore::ConfigItem.new(key: :provisioning_profile_path,
-                                       env_name: "TAB_PROVISIONING_PROFILE_PATH",
-                                       description: "The path of the provisioning profile to install",
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
-        ]
+        []
       end
 
       def self.authors
-        ["Luciano Marisi @lucianomarisi"]
+        [
+          "Luciano Marisi @lucianomarisi",
+          "Kane Cheshire @KaneCheshire"
+        ]
       end
 
       def self.is_supported?(platform)

--- a/actions/install_provisioning_profiles.rb
+++ b/actions/install_provisioning_profiles.rb
@@ -11,9 +11,14 @@ module Fastlane
         else
           profile_paths.each do |path|
             uuid = `grep UUID -A1 -a #{path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
-            destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{uuid.strip}.mobileprovision"
-            `cp #{path} #{destination}`
-            UI.success("Installed profile at path #{path} successfully")
+            destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning Profiles/#{uuid.strip}.mobileprovision"
+            begin
+              FileUtils.cp(path, destination)
+            rescue
+              UI.important("Failed to install profile at path #{path} to #{destination}")
+            else
+              UI.success("Installed profile at path #{path} successfully to #{destination}")
+            end
           end
         end
       end

--- a/actions/install_provisioning_profiles.rb
+++ b/actions/install_provisioning_profiles.rb
@@ -1,8 +1,5 @@
 module Fastlane
   module Actions
-    module SharedValues
-    end
-
     class InstallProvisioningProfilesAction < Action
       def self.run(params)
         profile_paths = Dir.glob("./**/*.mobileprovision")

--- a/actions/install_provisioning_profiles.rb
+++ b/actions/install_provisioning_profiles.rb
@@ -3,7 +3,7 @@ module Fastlane
     module SharedValues
     end
 
-    class InstallProvisioningProfileAction < Action
+    class InstallProvisioningProfilesAction < Action
       def self.run(params)
         profile_paths = Dir.glob("./**/*.mobileprovision")
         if profile_paths.empty?
@@ -13,7 +13,7 @@ module Fastlane
             uuid = `grep UUID -A1 -a #{path} | grep -io \"[-A-Z0-9]\\{36\\}\"`
             destination = "#{ENV['HOME']}/Library/MobileDevice/Provisioning\\\ Profiles/#{uuid.strip}.mobileprovision"
             `cp #{path} #{destination}`
-            UI.success("Installed profile at path #{path} succesfully")
+            UI.success("Installed profile at path #{path} successfully")
           end
         end
       end


### PR DESCRIPTION
This action is called when building with gym, but it doesn't support installing more than one profile. Instead of requiring the `TAB_PROVISIONING_PROFILE_PATH` environment variable, I think it's nicer to just look for any provisioning profiles included in the directory and install them automatically.

This also means we can remove the requirement of this variable completely, when my other PR to remove the need for a Provfile is merged in.

This fixes #44 