### PR TITLE
Fix release readme badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,59 @@
 # CHANGELOG
 
-## 3.0.0
+## [3.0.1]
+### Added
+- Release badge and link pointing to latest release version
 
-- Removed use of `TAB_EXPORT_METHOD`, instead extracting the export method from the environment's `GYM_EXPORT_OPTIONS` plist.
+### Changed
+- CHANGELOG format
+
+## [3.0.0]
+### Changed
 - If `FL_PROJECT_TEAM_ID` is not set, the team ID is extracted from the environment's `GYM_EXPORT_OPTIONS` plist.
 
-## 2.3.0
+### Removed
+- Use of `TAB_EXPORT_METHOD`, instead extracting the export method from the environment's `GYM_EXPORT_OPTIONS` plist.
 
-- Added lane dedicated to running `ui_test` schemes
+## [2.3.0]
+### Added
+- Lane dedicated to running `ui_test` schemes
 
-## 2.2.0
+## [2.2.0]
+### Added
+- Support for signing multiple target projects using Provfile's
 
-- Added support for signing multiple target projects using Provfile's
+## [2.1.0]
+### Added
+- `deploy_to_test_flight` for building and uploading to iTunes Connect
 
-## 2.1.0
-
-- Added `deploy_to_test_flight` for building and uploading to iTunes Connect
-
-## 2.0.0
-
-- Renamed `hockey` to `deploy_to_hockey`
-- Renamed `hockey_no_test` to `deploy_to_hockey_no_test`
-- Added new enviroment variable `TAB_EXPORT_METHOD` needed for `gym`, possible values are:
+## [2.0.0]
+### Added
+- New enviroment variable `TAB_EXPORT_METHOD` needed for `gym`, possible values are:
 	- "app-store"
 	- "ad-hoc"
 	- "development"
 	- "enterprise" // If not set this is used by default
 
-## 1.6.0
+### Changed
+- Renamed `hockey` to `deploy_to_hockey`
+- Renamed `hockey_no_test` to `deploy_to_hockey_no_test`
 
-- Added support for updating the team ID if `FL_PROJECT_SIGNING_PROJECT_PATH` and  `FL_PROJECT_TEAM_ID` are set
+## [1.6.0]
+### Added
+- Support for updating the team ID if `FL_PROJECT_SIGNING_PROJECT_PATH` and  `FL_PROJECT_TEAM_ID` are set
 
-## 1.5.0
+## [1.5.0]
+### Added
+- `local_build` for building ipas locally
 
-- Added `local_build` for building ipas locally
-
-## 1.4.0
-
+## [1.4.0]
+### Added
 - Support for updating `PRODUCT_BUNDLE_IDENTIFIER`
 
-## 1.3.0
-
+## [1.3.0]
+### Added
 - Support for installing a provisioning profile
 
-## 1.2.0
-
+## [1.2.0]
+### Added
 - Support for Xcode 8 provisioning profile specifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,32 @@
 # CHANGELOG
 
-## [3.0.1]
+## [3.0.1](https://github.com/theappbusiness/MasterFastfile/releases/tag/3.0.1)
 ### Added
 - Release badge and link pointing to latest release version
 
 ### Changed
 - CHANGELOG format
 
-## [3.0.0]
+## [3.0.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/3.0.0)
 ### Changed
 - If `FL_PROJECT_TEAM_ID` is not set, the team ID is extracted from the environment's `GYM_EXPORT_OPTIONS` plist.
 
 ### Removed
 - Use of `TAB_EXPORT_METHOD`, instead extracting the export method from the environment's `GYM_EXPORT_OPTIONS` plist.
 
-## [2.3.0]
+## [2.3.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/2.3.0)
 ### Added
 - Lane dedicated to running `ui_test` schemes
 
-## [2.2.0]
+## [2.2.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/2.2.0)
 ### Added
 - Support for signing multiple target projects using Provfile's
 
-## [2.1.0]
+## [2.1.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/2.1.0)
 ### Added
 - `deploy_to_test_flight` for building and uploading to iTunes Connect
 
-## [2.0.0]
+## [2.0.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/2.0.0)
 ### Added
 - New enviroment variable `TAB_EXPORT_METHOD` needed for `gym`, possible values are:
 	- "app-store"
@@ -38,22 +38,22 @@
 - Renamed `hockey` to `deploy_to_hockey`
 - Renamed `hockey_no_test` to `deploy_to_hockey_no_test`
 
-## [1.6.0]
+## [1.6.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/1.6.0)
 ### Added
 - Support for updating the team ID if `FL_PROJECT_SIGNING_PROJECT_PATH` and  `FL_PROJECT_TEAM_ID` are set
 
-## [1.5.0]
+## [1.5.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/1.5.0)
 ### Added
 - `local_build` for building ipas locally
 
-## [1.4.0]
+## [1.4.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/1.4.0)
 ### Added
 - Support for updating `PRODUCT_BUNDLE_IDENTIFIER`
 
-## [1.3.0]
+## [1.3.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/1.3.0)
 ### Added
 - Support for installing a provisioning profile
 
-## [1.2.0]
+## [1.2.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/1.2.0)
 ### Added
 - Support for Xcode 8 provisioning profile specifier

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ![The App Business](./MasterFastfile.png)
 
 # MasterFastfile
-
-[![Release](https://img.shields.io/badge/release-3.0.0-green.svg)](https://github.com/theappbusiness/MasterFastfile/releases/tag/3.0.0)
+[![GitHub release](https://img.shields.io/github/release/theappbusiness/masterfastfile.svg)](https://github.com/theappbusiness/MasterFastfile/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/theappbusiness/MasterFastfile/blob/master/LICENSE)
 
 To setup your project to use the TAB MasterFastfile, navigate to your project root and run the following command:
@@ -16,7 +15,7 @@ Then setup your environments using the `.env` files created for you. To complete
 To use the MasterFastfile add the following command to your Fastfile:
 
 ```ruby
-import_from_git(url: 'https://github.com/theappbusiness/MasterFastfile.git', branch: '3.0.0', path: 'Fastfile')
+import_from_git(url: 'https://github.com/theappbusiness/MasterFastfile.git', branch: '3.0.1', path: 'Fastfile')
 ```
 For more detailed instructions [see our wiki](https://github.com/theappbusiness/MasterFastfile/wiki)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![The App Business](./MasterFastfile.png)
 
 # MasterFastfile
-[![GitHub release](https://img.shields.io/github/release/theappbusiness/masterfastfile.svg)](https://github.com/theappbusiness/MasterFastfile/releases/latest)
+[![GitHub release](https://img.shields.io/github/release/theappbusiness/masterfastfile/all.svg)](https://github.com/theappbusiness/MasterFastfile/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/theappbusiness/MasterFastfile/blob/master/LICENSE)
 
 To setup your project to use the TAB MasterFastfile, navigate to your project root and run the following command:


### PR DESCRIPTION
Addressing Issue #42 

Trying to make our `release` badge in readme auto-update based on the latest release.

The underlaying issue is related to GitHub not tagging our latest release properly but we also need to make the badge image dynamic.

Planning on publishing a `3.0.1` pre-release after to try and make it work.