### PR TITLE
feature/build-number-in-slack-message

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -184,7 +184,7 @@ def _notify_slack
   hockey_download_url = lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK]
   build_number = _build_number
   if !hockey_download_url.nil?
-    message_prefix = build_number.to_s.empty? ? "A new build" : "Build #{build_number}"
+    message_prefix = build_number.to_s.empty? ? 'A new build' : "Build #{build_number}"
     new_build_message = "#{message_prefix} is available on <#{hockey_download_url}|hockey>"
     slack(message: new_build_message)
   else

--- a/Fastfile
+++ b/Fastfile
@@ -182,8 +182,10 @@ end
 def _notify_slack
   return if ENV['FL_SLACK_CHANNEL'].to_s.strip.empty?
   hockey_download_url = lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK]
+  build_number = _build_number
   if !hockey_download_url.nil?
-    new_build_message = "A new build is available on <#{hockey_download_url}|hockey>"
+    message_prefix = build_number.to_s.empty? "A new build" : "Build #{build_number}"
+    new_build_message = "#{message_prefix} is available on <#{hockey_download_url}|hockey>"
     slack(message: new_build_message)
   else
     slack

--- a/Fastfile
+++ b/Fastfile
@@ -184,7 +184,7 @@ def _notify_slack
   hockey_download_url = lane_context[SharedValues::HOCKEY_DOWNLOAD_LINK]
   build_number = _build_number
   if !hockey_download_url.nil?
-    message_prefix = build_number.to_s.empty? "A new build" : "Build #{build_number}"
+    message_prefix = build_number.to_s.empty? ? "A new build" : "Build #{build_number}"
     new_build_message = "#{message_prefix} is available on <#{hockey_download_url}|hockey>"
     slack(message: new_build_message)
   else


### PR DESCRIPTION
Addresses #58  

Add build number to hockey slack message, revert to default copy if build number unavailable