### PR TITLE
Use intended Bundle ID environment setting for each action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - All provisioning profiles included in the `fastlane` directory now get installed automatically.
 - Updated `setup.sh`.
 - Fixed an issue with including a Hockey download link when messaging to Slack.
+- Fixed an issue where using `get_current_version` with the latest version of Fastlane would cause a prompt for the target.
 
 ## [3.0.1](https://github.com/theappbusiness/MasterFastfile/releases/tag/3.0.1)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [4.0.0]("https://github.com/theappbusiness/MasterFastfile/releases/tag/4.0.0")
+### Changed
+- Multiple code-level changes for addressing Rubocop errors.
+- Provfiles are no longer used, instead you should define export options.
+- All provisioning profiles included in the `fastlane` directory now get installed automatically.
+- Updated `setup.sh`
+
 ## [3.0.1](https://github.com/theappbusiness/MasterFastfile/releases/tag/3.0.1)
 ### Added
 - Release badge and link pointing to latest release version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Multiple code-level changes for addressing Rubocop errors.
 - Provfiles are no longer used, instead you should define export options.
 - All provisioning profiles included in the `fastlane` directory now get installed automatically.
-- Updated `setup.sh`
+- Updated `setup.sh`.
+- Fixed an issue with including a Hockey download link when messaging to Slack.
 
 ## [3.0.1](https://github.com/theappbusiness/MasterFastfile/releases/tag/3.0.1)
 ### Added

--- a/Fastfile
+++ b/Fastfile
@@ -109,10 +109,8 @@ def _set_build_number
 end
 
 def _build_ipa
-  app_id = ENV['FL_UPDATE_APP_IDENTIFIER'] || ENV['FL_UPDATE_PLIST_APP_IDENTIFIER']
   update_app_identifier(xcodeproj: ENV['FL_UPDATE_PLIST_PROJECT_PATH'],
-                        plist_path: ENV['FL_UPDATE_PLIST_PATH'],
-                        app_identifier: app_id)
+                        plist_path: ENV['FL_UPDATE_PLIST_PATH'])
   update_info_plist
   _build_with_gym
 end

--- a/Fastfile
+++ b/Fastfile
@@ -109,9 +109,10 @@ def _set_build_number
 end
 
 def _build_ipa
+  app_id = ENV['FL_UPDATE_APP_IDENTIFIER'] || ENV['FL_UPDATE_PLIST_APP_IDENTIFIER']
   update_app_identifier(xcodeproj: ENV['FL_UPDATE_PLIST_PROJECT_PATH'],
-                        plist_path: ENV['FL_UPDATE_PLIST_PATH'],
-                        app_identifier: ENV['FL_UPDATE_PLIST_APP_IDENTIFIER'])
+                        plist_path: ENV['FL_UPDATE_PLIST_PATH']
+                        app_identifier: app_id)
   update_info_plist
   _build_with_gym
 end

--- a/Fastfile
+++ b/Fastfile
@@ -111,7 +111,7 @@ end
 def _build_ipa
   app_id = ENV['FL_UPDATE_APP_IDENTIFIER'] || ENV['FL_UPDATE_PLIST_APP_IDENTIFIER']
   update_app_identifier(xcodeproj: ENV['FL_UPDATE_PLIST_PROJECT_PATH'],
-                        plist_path: ENV['FL_UPDATE_PLIST_PATH']
+                        plist_path: ENV['FL_UPDATE_PLIST_PATH'],
                         app_identifier: app_id)
   update_info_plist
   _build_with_gym

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then setup your environments using the `.env` files created for you. To complete
 To use the MasterFastfile add the following command to your Fastfile:
 
 ```ruby
-import_from_git(url: 'https://github.com/theappbusiness/MasterFastfile.git', branch: '3.0.1', path: 'Fastfile')
+import_from_git(url: 'https://github.com/theappbusiness/MasterFastfile.git', branch: '4.0.0', path: 'Fastfile')
 ```
 For more detailed instructions [see our wiki](https://github.com/theappbusiness/MasterFastfile/wiki)
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,16 +13,21 @@ function make_default_env_file {
 #More information on available environment variables can be found here https://github.com/theappbusiness/MasterFastfile/wiki/Quick-simple-setup-using-TAB-defaults
 
 FL_PROJECT_SIGNING_PROJECT_PATH="./yourproject.xcodeproj" # Path to your project (not workspace)
+FL_UPDATE_PLIST_APP_IDENTIFIER="" #The app identifier you want your main target (the host app) to have
+GYM_CODE_SIGNING_IDENTITY="" #Code Sign Identitify
+GYM_EXPORT_OPTIONS="" #The export options, used for finding the export method and provisioning
+
 FL_HOCKEY_API_TOKEN="" #Hocky API Token
 FL_HOCKEY_OWNER_ID="" #Hockey Organisation ID (number not name)
 FL_UPDATE_PLIST_PATH="" #Path to Info.plist
-GYM_CODE_SIGNING_IDENTITY="" #Code Sign Identitify
 FL_HOCKEY_TEAMS="" #Hockey ID (number not name)
 FL_HOCKEY_NOTIFY= #Email team when new build avialable? 0 = No, 1 = Yes
+
 ICON_OVERLAY_ASSETS_BUNDLE="" #Path to .xcassets
-TAB_USE_TIME_FOR_BUILD_NUMBER= #Use Time and date for build number or BUILD_NUMBER environment variable (created by jenkis or team city) true = use time, false = use BUILD_NUMBER
+TAB_USE_TIME_FOR_BUILD_NUMBER= #Use Time and date for build number or BUILD_NUMBER environment variable (created by Jenkins or Team City) true = use time, false = use BUILD_NUMBER
+
 ITUNES_CONNECT_USERNAME="" #iTunes Connect login (usually email address)
-ITUNES_CONNECT_TEAM_ID="" #The ID of your iTunes Connect team if you're in multiple teams
+ITUNES_CONNECT_TEAM_ID="" #The ID of your iTunes Connect team if you're in multiple teams https://github.com/fastlane/fastlane/issues/4301#issuecomment-253461017
 ITUNES_CONNECT_PROVIDER="" #The provider short name to be used with the iTMSTransporter to identify your team
 EOF
 }


### PR DESCRIPTION
(seems like there's quite a bit of stuff on `master` that isn't on `develop`).

the only change is removing `app_identifier: ENV['FL_UPDATE_PLIST_APP_IDENTIFIER']` because this will be used in the subsequent call to `update_info_plist`. We don't *think* this breaks backwards compatibility.

Rationale: we encountered a subtle bug when using multiple prov profiles for deployments to Hockey (zoom out: we're adding support for universal links, handoff etc, so we can no longer use a wildcard prov profile).

On subsequent runs, the block https://github.com/fastlane/fastlane/blob/665a23e6351702bbd6980fe1f7ec75a6f1f7bfa6/fastlane/lib/fastlane/actions/update_app_identifier.rb#L17 would not get called, because in the previous run, `update_info_plist` had overwritten `CFBundleIdentifier`. This resulted in the prov profile from the _previous_ run being embedded in the App bundle (eg, if you ran PPE, then PRODTEST, the latter would end up with PPE's prov profile). 

This change, combined with us replacing `FL_UPDATE_PLIST_APP_IDENTIFIER` with `FL_UPDATE_APP_IDENTIFIER` fixes the issue for us.

We probably could also fix the issue by doing a `git clean` between hockey deploys, but this change improves the fastfile, we think.