### PR TITLE
Failing UI tests can now be retried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,25 @@
 # CHANGELOG
 
+## [6.0.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/6.0.0)
+
+- UI tests are now executed using `fastlane-plugin-test_center` - https://github.com/lyndsey-ferguson/fastlane-plugin-test_center.
+- Added new (optional) environment variable `MULTI_SCAN_TRY_COUNT` to set the number of times a test is retried before it's considered a fail.
+- `TAB_UI_TEST_DEVICES` now supports the setting of multiple devices, as the name implies. If setting multiple, these should be ':' separated.
+- Added new (optional) environment variable `MULTI_SCAN_PARALLEL_WORKER_COUNT` to set the number of simulators for batched UI tests.
+- Added new (optional) environment variable `TAB_UNIT_TEST_DEVICE` to be able to set a unit test device independently. The `device` scan parameter was used previously which conflicted with the use of `devices` by `multi-scan`.
+
 ## [5.0.1](https://github.com/theappbusiness/MasterFastfile/releases/tag/5.0.1)
 
-Fixes an issue that was causing hockey uploads to fail.
+- Fixes an issue that was causing hockey uploads to fail.
 
 ## [5.0.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/5.0.0)
 
-`TAB_PRIMARY_TARGET` environment variable is now mandatory for projects using Icon Overlay.
+- `TAB_PRIMARY_TARGET` environment variable is now mandatory for projects using Icon Overlay.
 
-As of v 2.86.0, fastlane requires a target for get_version_number, used for icon badging.
-
+- As of v 2.86.0, fastlane requires a target for get_version_number, used for icon badging.
 See discussion here: fastlane/fastlane#12177. See PR #64 for details.
-
-Use intended Bundle ID environment setting for each action
-
-Distinguishing between `FL_UPDATE_PLIST_APP_IDENTIFIER` and `FL_UPDATE_APP_IDENTIFIER`. See PR #63 for details.
+- Use intended Bundle ID environment setting for each action
+- Distinguishing between `FL_UPDATE_PLIST_APP_IDENTIFIER` and `FL_UPDATE_APP_IDENTIFIER`. See PR #63 for details.
 
 ## [4.0.0](https://github.com/theappbusiness/MasterFastfile/releases/tag/4.0.0)
 ### Changed

--- a/Fastfile
+++ b/Fastfile
@@ -150,12 +150,11 @@ def _build_with_gym
   export_method = _get_export_method
   xcconfig_filename = Dir.pwd + '/TAB.release.xcconfig'
   create_xcconfig(filename: xcconfig_filename)
-  gym(configuration: _configuration, export_method: export_method, xcconfig: xcconfig_filename)
+  gym(configuration: _get_build_config, export_method: export_method, xcconfig: xcconfig_filename)
 end
 
-def _configuration
-  value = get_info_plist_value(path: ENV['GYM_EXPORT_OPTIONS'], key: 'configuration')
-  return value.nil? ? "Release" : value
+def _get_build_config
+  return ENV['BUILD_CONFIGURATION'].nil? ? "Release" : ENV['BUILD_CONFIGURATION']
 end
 
 def _get_export_method

--- a/Fastfile
+++ b/Fastfile
@@ -37,9 +37,9 @@ lane :ui_test do
       else
         UI.important('Not all UI tests have passed and the maximum try count has been reached.')
       end
-
-      UI.message("testrun_info: #{testrun_info}")
     end
+    UI.message("Attempt #{testrun_info[:try_count]} out of #{max_test_try_count} run info: #{testrun_info}")
+
   end
 
   result = multi_scan(

--- a/Fastfile
+++ b/Fastfile
@@ -154,7 +154,8 @@ def _build_with_gym
 end
 
 def _configuration
-  return ENV['GYM_EXPORT_OPTIONS'].nil? ? "Release" : get_info_plist_value(path: ENV['GYM_EXPORT_OPTIONS'], key: 'configuration')
+  value = get_info_plist_value(path: ENV['GYM_EXPORT_OPTIONS'], key: 'configuration')
+  return value.nil? ? "Release" : value
 end
 
 def _get_export_method

--- a/Fastfile
+++ b/Fastfile
@@ -150,7 +150,7 @@ def _build_with_gym
   export_method = _get_export_method
   xcconfig_filename = Dir.pwd + '/TAB.release.xcconfig'
   create_xcconfig(filename: xcconfig_filename)
-  gym(export_method: export_method, xcconfig: xcconfig_filename)
+  gym(configuration: "Debug", export_method: export_method, xcconfig: xcconfig_filename)
 end
 
 def _get_export_method

--- a/Fastfile
+++ b/Fastfile
@@ -147,6 +147,7 @@ end
 def _build_with_gym
   install_provisioning_profiles
   _update_team_id_if_necessary
+  _update_code_signing_type_if_necessary
   export_method = _get_export_method
   xcconfig_filename = Dir.pwd + '/TAB.release.xcconfig'
   create_xcconfig(filename: xcconfig_filename)
@@ -178,6 +179,16 @@ def _update_team_id_if_necessary
     update_project_team(path: project_path, teamid: team_id)
   else
     UI.message('Unable to find project path or project team so skipping updating project team.')
+  end
+end
+
+def _update_code_signing_type_if_necessary
+  automatic_code_signing = ENV['FL_USE_AUTOMATIC_CODE_SIGNING']
+  if automatic_code_signing
+    UI.message("Updating code signing to '#{automatic_code_signing == 'true' ? 'automatic' : 'manual'}'")
+    update_code_signing_settings(
+      use_automatic_signing: automatic_code_signing == 'true',
+    )
   end
 end
 

--- a/Fastfile
+++ b/Fastfile
@@ -107,7 +107,7 @@ def _setup
   xcode_select(ENV['TAB_XCODE_PATH']) if is_ci && !ENV['TAB_XCODE_PATH'].nil?
 
   unless ENV['TAB_UI_TEST_SCHEME'].nil? # rubocop:disable Style/GuardClause
-    ENV['TAB_REPORT_FORMATS'] = 'html' if ENV['TAB_OUTPUT_TYPES'].nil?
+    ENV['TAB_REPORT_FORMATS'] = 'html' if ENV['TAB_REPORT_FORMATS'].nil?
     ENV['TAB_UI_TEST_DEVICES'] ||= ['iPhone 8']
   end
 end

--- a/Fastfile
+++ b/Fastfile
@@ -151,7 +151,13 @@ def _build_with_gym
   export_method = _get_export_method
   xcconfig_filename = Dir.pwd + '/TAB.release.xcconfig'
   create_xcconfig(filename: xcconfig_filename)
-  gym(configuration: _get_build_config, export_method: export_method, xcconfig: xcconfig_filename)
+
+  gym(
+    configuration: _get_build_config,
+    export_method: export_method,
+    xcconfig: xcconfig_filename,
+    xcargs: ENV['GYM_XCARGS'] || ''
+  )
 end
 
 def _get_build_config

--- a/Fastfile
+++ b/Fastfile
@@ -150,7 +150,11 @@ def _build_with_gym
   export_method = _get_export_method
   xcconfig_filename = Dir.pwd + '/TAB.release.xcconfig'
   create_xcconfig(filename: xcconfig_filename)
-  gym(configuration: "Debug", export_method: export_method, xcconfig: xcconfig_filename)
+  gym(configuration: _configuration, export_method: export_method, xcconfig: xcconfig_filename)
+end
+
+def _configuration
+  return ENV['GYM_EXPORT_OPTIONS'].nil? ? "Release" : get_info_plist_value(path: ENV['GYM_EXPORT_OPTIONS'], key: 'configuration')
 end
 
 def _get_export_method

--- a/Fastfile
+++ b/Fastfile
@@ -154,7 +154,7 @@ def _build_with_gym
 end
 
 def _get_build_config
-  return ENV['BUILD_CONFIGURATION'].nil? ? "Release" : ENV['BUILD_CONFIGURATION']
+  return ENV['FL_BUILD_CONFIGURATION'].nil? ? "Release" : ENV['FL_BUILD_CONFIGURATION']
 end
 
 def _get_export_method

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ The MasterFastfile uses whichever export options you have set for the `GYM_EXPOR
 
 ## Dependencies
 
+### Test Center plugin
+Add the test center plugin to your fastlane setup for the `ui_test` lane. Follow the guide [here](https://github.com/lyndsey-ferguson/fastlane-plugin-test_center)
+
 ### App Center plugin
 Add the app center plugin to your fastlane setup for the app center lanes. Follow the guide [here](https://github.com/microsoft/fastlane-plugin-appcenter)
 


### PR DESCRIPTION
* Now using `fastlane-plugin-test_center` for UI tests - https://github.com/lyndsey-ferguson/fastlane-plugin-test_center
* Added new (optional) environment variable `MULTI_SCAN_TRY_COUNT` to set the number of times a test is retried before it's considered a fail.
* `TAB_UI_TEST_DEVICES` now supports the setting of multiple devices, as the name implies. If setting multiple, these should be ':' separated.
* Added new (optional) environment variable `MULTI_SCAN_PARALLEL_WORKER_COUNT` to set the number of simulators for batched UI tests.
* Added new (optional) environment variable `TAB_UNIT_TEST_DEVICE` to be able to set a unit test device independently. The `device` scan parameter was used previously which conflicted with the use of `devices` by `multi-scan`.
* Updated `changelog` for version 6.0.0 changes.
* Updated `readme` for version 6.0.0 changes.